### PR TITLE
Property synctatic sugar support

### DIFF
--- a/30log.lua
+++ b/30log.lua
@@ -3,36 +3,25 @@ local baseMt, _instances, _classes, class = {}, setmetatable({},{__mode='k'}), s
 local function deep_copy(t, dest, aType)
   local t, r = t or {}, dest or {}
   for k,v in pairs(t) do
-    if aType and type(v)==aType then r[k] = v elseif not aType then
-      if type(v) == 'table' and k ~= "__index" then r[k] = deep_copy(v) else r[k] = v end
-    end
+    if aType and type(v)==aType then r[k] = v elseif not aType then if type(v) == 'table' and k ~= "__index" then r[k] = deep_copy(v) else r[k] = v end end
   end; return r
 end
-local function instantiate(self,...)
-  assert(_classes[self],'new() should be called from a class.')
+local function instantiate(self,...) assert(_classes[self],'new() should be called from a class.')
   local instance = deep_copy(self) ; _instances[instance] = tostring(instance); setmetatable(instance,self)
   if self.__init then if type(self.__init) == 'table' then deep_copy(self.__init, instance) else self.__init(instance, ...) end; end; return instance
 end
-local function extends(self,extra_params)
-  local heir = {}; _classes[heir] = tostring(heir); deep_copy(extra_params, deep_copy(self, heir));
-  heir.__index, heir.super = heir.__index or heir, self; return setmetatable(heir,self)
-end
-baseMt = { __call = function (self,...) return self:new(...) end, __tostring = function(self,...)
-  if _instances[self] then return ('object(of %s):<%s>'):format((rawget(getmetatable(self),'__name') or '?'), _instances[self]) end
-  return _classes[self] and ('class(%s):<%s>'):format((rawget(self,'__name') or '?'),_classes[self]) or self
-end}
+local function extends(self,extra_params) local heir = {}; _classes[heir] = tostring(heir); deep_copy(extra_params, deep_copy(self, heir)); heir.__index, heir.super = heir.__index or heir, self; return setmetatable(heir,self) end
+baseMt = { __call = function (self,...) return self:new(...) end, __tostring = function(self,...) if _instances[self] then return ('object(of %s):<%s>'):format((rawget(getmetatable(self),'__name') or '?'), _instances[self]) else return _classes[self] and ('class(%s):<%s>'):format((rawget(self,'__name') or '?'),_classes[self]) or self end end}
 class = function(attr)
   local c = deep_copy(attr) ; _classes[c] = tostring(c);
   c.include = function(self,include) assert(_classes[self], 'Mixins can only be used on classes.'); return deep_copy(include, self, 'function') end
-  c.property = function(self, name, getter, setter)
-    assert(_classes[self], 'Properties can only be defined for classes')
+  c.property = function(self, name, getter, setter) assert(_classes[self], 'Properties can only be defined for classes')
     if not(self.__getters or self.__setters) then
       self.__getters = {}; self.__setters = {}
       self.__index = function(self, index) local getter = self.__getters[index]; if getter == false then error("The " .. index .. " property is not readable.") end; if getter then return rawget(self, getter)(self) else return rawget(self, index) end end
       self.__newindex = function(self, index, value) local setter = self.__setters[index]; if setter == false then error("The " .. index .. " property is not writeable.") end; if setter then rawget(self, setter)(self, value) else rawset(self, index, value) end end
     end
-    if type(getter) == "function" then rawset(self, "__get_" .. name, getter); getter = "__get_" .. name end
-    if type(setter) == "function" then rawset(self, "__set_" .. name, setter); setter = "__set_" .. name end
+    if type(getter) == "function" then rawset(self, "__get_" .. name, getter); getter = "__get_" .. name end; if type(setter) == "function" then rawset(self, "__set_" .. name, setter); setter = "__set_" .. name end;
     self.__getters[name] = getter or false; self.__setters[name] = setter or false
   end
   c.new, c.extends, c.__index, c.__call, c.__tostring = instantiate, extends, c, baseMt.__call, baseMt.__tostring;

--- a/30log.lua
+++ b/30log.lua
@@ -15,7 +15,7 @@ local function instantiate(self,...)
 end
 local function extends(self,extra_params)
   local heir = {}; _classes[heir] = tostring(heir); deep_copy(extra_params, deep_copy(self, heir));
-  heir.__index, heir.super = heir, self; return setmetatable(heir,self)
+  heir.__index, heir.super = heir.__index or heir, self; return setmetatable(heir,self)
 end
 baseMt = { __call = function (self,...) return self:new(...) end, __tostring = function(self,...)
   if _instances[self] then return ('object(of %s):<%s>'):format((rawget(getmetatable(self),'__name') or '?'), _instances[self]) end
@@ -24,6 +24,17 @@ end}
 class = function(attr)
   local c = deep_copy(attr) ; _classes[c] = tostring(c);
   c.include = function(self,include) assert(_classes[self], 'Mixins can only be used on classes.'); return deep_copy(include, self, 'function') end
+  c.property = function(self, name, getter, setter)
+    assert(_classes[self], 'Properties can only be defined for classes')
+    if not(self.__getters or self.__setters) then
+      self.__getters = {}; self.__setters = {}
+      self.__index = function(self, index) local getter = self.__getters[index]; if getter == false then error("The " .. index .. " property is not readable.") end; if getter then return rawget(self, getter)(self) else return rawget(self, index) end end
+      self.__newindex = function(self, index, value) local setter = self.__setters[index]; if setter == false then error("The " .. index .. " property is not writeable.") end; if setter then rawget(self, setter)(self, value) else rawset(self, index, value) end end
+    end
+    if type(getter) == "function" then rawset(self, "__get_" .. name, getter); getter = "__get_" .. name end
+    if type(setter) == "function" then rawset(self, "__set_" .. name, setter); setter = "__set_" .. name end
+    self.__getters[name] = getter or false; self.__setters[name] = setter or false
+  end
   c.new, c.extends, c.__index, c.__call, c.__tostring = instantiate, extends, c, baseMt.__call, baseMt.__tostring;
   c.is = function(self, kind) local super; while true do super = getmetatable(super or self) ; if super == kind or super == nil then break end ; end;
   return kind and (super == kind) end; return setmetatable(c,baseMt)

--- a/30logclean.lua
+++ b/30logclean.lua
@@ -12,19 +12,19 @@ local class
 local function deep_copy(t, dest, aType)
   local t = t or {}
   local r = dest or {}
-  
+
   for k,v in pairs(t) do
-    if aType and type(v)==aType then 
-      r[k] = v 
+    if aType and type(v)==aType then
+      r[k] = v
     elseif not aType then
-      if type(v) == 'table' and k ~= "__index" then 
-        r[k] = deep_copy(v) 
+      if type(v) == 'table' and k ~= "__index" then
+        r[k] = deep_copy(v)
       else
         r[k] = v
       end
     end
   end
-  
+
   return r
 end
 
@@ -33,7 +33,7 @@ local function instantiate(self,...)
   local instance = deep_copy(self)
   _instances[instance] = tostring(instance)
   setmetatable(instance,self)
-  
+
   if self.__init then
     if type(self.__init) == 'table' then
       deep_copy(self.__init, instance)
@@ -41,7 +41,7 @@ local function instantiate(self,...)
       self.__init(instance, ...)
     end
   end
-  
+
   return instance
 end
 
@@ -49,7 +49,7 @@ local function extends(self,extra_params)
   local heir = {}
   _classes[heir] = tostring(heir)
   deep_copy(extra_params, deep_copy(self, heir))
-  heir.__index = heir
+  heir.__index = heir.__index or heir
   heir.super = self
   return setmetatable(heir,self)
 end
@@ -58,19 +58,19 @@ baseMt = {
   __call = function (self,...)
     return self:new(...)
   end,
-  
+
   __tostring = function(self,...)
     if _instances[self] then
-      return 
+      return
         ('object(of %s):<%s>')
           :format((rawget(getmetatable(self),'__name') or '?'), _instances[self])
     end
-    
+
     return
-      _classes[self] and 
+      _classes[self] and
       ('class(%s):<%s>')
-        :format((rawget(self,'__name') or '?'),_classes[self]) or 
-      self      
+        :format((rawget(self,'__name') or '?'),_classes[self]) or
+      self
   end
 }
 
@@ -81,16 +81,49 @@ class = function(attr)
     assert(_classes[self], 'Mixins can only be used on classes.')
     return deep_copy(include, self, 'function')
   end
-  
+
+  c.property = function(self, name, getter, setter)
+    assert(_classes[self], 'Properties can only be defined for classes')
+    if not(self.__getters or self.__setters) then
+      self.__getters = {}
+      self.__setters = {}
+
+      self.__index = function(self, index)
+        local getter = self.__getters[index]
+        if getter == false then error("The " .. index .. " property is not readable.") end
+        if getter then return rawget(self, getter)(self) else return rawget(self, index) end
+      end
+
+      self.__newindex = function(self, index, value)
+        local setter = self.__setters[index]
+        if setter == false then error("The " .. index .. " property is not writeable.") end
+        if setter then rawget(self, setter)(self, value) else rawset(self, index, value) end
+      end
+    end
+
+    if type(getter) == "function" then
+        rawset(self, "__get_" .. name, getter)
+        getter = "__get_" .. name
+    end
+
+    if type(setter) == "function" then
+        rawset(self, "__set_" .. name, setter)
+        setter = "__set_" .. name
+    end
+
+    self.__getters[name] = getter or false
+    self.__setters[name] = setter or false
+  end
+
   c.new = instantiate
   c.extends = extends
   c.__index = c
   c.__call = baseMt.__call
   c.__tostring = baseMt.__tostring
-  
+
   c.is = function(self, kind)
     local super
-    while true do 
+    while true do
       super = getmetatable(super or self)
       if super == kind or super == nil then break end
     end

--- a/30logglobal.lua
+++ b/30logglobal.lua
@@ -3,36 +3,25 @@ local baseMt, _instances, _classes = {}, setmetatable({},{__mode='k'}), setmetat
 local function deep_copy(t, dest, aType)
   local t, r = t or {}, dest or {}
   for k,v in pairs(t) do
-    if aType and type(v)==aType then r[k] = v elseif not aType then
-      if type(v) == 'table' and k ~= "__index" then r[k] = deep_copy(v) else r[k] = v end
-    end
+    if aType and type(v)==aType then r[k] = v elseif not aType then if type(v) == 'table' and k ~= "__index" then r[k] = deep_copy(v) else r[k] = v end end
   end; return r
 end
-local function instantiate(self,...)
-  assert(_classes[self],'new() should be called from a class.')
+local function instantiate(self,...) assert(_classes[self],'new() should be called from a class.')
   local instance = deep_copy(self) ; _instances[instance] = tostring(instance); setmetatable(instance,self)
   if self.__init then if type(self.__init) == 'table' then deep_copy(self.__init, instance) else self.__init(instance, ...) end; end; return instance
 end
-local function extends(self,extra_params)
-  local heir = {}; _classes[heir] = tostring(heir); deep_copy(extra_params, deep_copy(self, heir));
-  heir.__index, heir.super = heir.__index or heir, self; return setmetatable(heir,self)
-end
-baseMt = { __call = function (self,...) return self:new(...) end, __tostring = function(self,...)
-  if _instances[self] then return ('object(of %s):<%s>'):format((rawget(getmetatable(self),'__name') or '?'), _instances[self]) end
-  return _classes[self] and ('class(%s):<%s>'):format((rawget(self,'__name') or '?'),_classes[self]) or self
-end}
+local function extends(self,extra_params) local heir = {}; _classes[heir] = tostring(heir); deep_copy(extra_params, deep_copy(self, heir)); heir.__index, heir.super = heir.__index or heir, self; return setmetatable(heir,self) end
+baseMt = { __call = function (self,...) return self:new(...) end, __tostring = function(self,...) if _instances[self] then return ('object(of %s):<%s>'):format((rawget(getmetatable(self),'__name') or '?'), _instances[self]) else return _classes[self] and ('class(%s):<%s>'):format((rawget(self,'__name') or '?'),_classes[self]) or self end end}
 class = function(attr)
   local c = deep_copy(attr) ; _classes[c] = tostring(c);
   c.include = function(self,include) assert(_classes[self], 'Mixins can only be used on classes.'); return deep_copy(include, self, 'function') end
-  c.property = function(self, name, getter, setter)
-    assert(_classes[self], 'Properties can only be defined for classes')
+  c.property = function(self, name, getter, setter) assert(_classes[self], 'Properties can only be defined for classes')
     if not(self.__getters or self.__setters) then
       self.__getters = {}; self.__setters = {}
       self.__index = function(self, index) local getter = self.__getters[index]; if getter == false then error("The " .. index .. " property is not readable.") end; if getter then return rawget(self, getter)(self) else return rawget(self, index) end end
       self.__newindex = function(self, index, value) local setter = self.__setters[index]; if setter == false then error("The " .. index .. " property is not writeable.") end; if setter then rawget(self, setter)(self, value) else rawset(self, index, value) end end
     end
-    if type(getter) == "function" then rawset(self, "__get_" .. name, getter); getter = "__get_" .. name end
-    if type(setter) == "function" then rawset(self, "__set_" .. name, setter); setter = "__set_" .. name end
+    if type(getter) == "function" then rawset(self, "__get_" .. name, getter); getter = "__get_" .. name end; if type(setter) == "function" then rawset(self, "__set_" .. name, setter); setter = "__set_" .. name end;
     self.__getters[name] = getter or false; self.__setters[name] = setter or false
   end
   c.new, c.extends, c.__index, c.__call, c.__tostring = instantiate, extends, c, baseMt.__call, baseMt.__tostring;

--- a/30logglobal.lua
+++ b/30logglobal.lua
@@ -15,7 +15,7 @@ local function instantiate(self,...)
 end
 local function extends(self,extra_params)
   local heir = {}; _classes[heir] = tostring(heir); deep_copy(extra_params, deep_copy(self, heir));
-  heir.__index, heir.super = heir, self; return setmetatable(heir,self)
+  heir.__index, heir.super = heir.__index or heir, self; return setmetatable(heir,self)
 end
 baseMt = { __call = function (self,...) return self:new(...) end, __tostring = function(self,...)
   if _instances[self] then return ('object(of %s):<%s>'):format((rawget(getmetatable(self),'__name') or '?'), _instances[self]) end
@@ -24,6 +24,17 @@ end}
 class = function(attr)
   local c = deep_copy(attr) ; _classes[c] = tostring(c);
   c.include = function(self,include) assert(_classes[self], 'Mixins can only be used on classes.'); return deep_copy(include, self, 'function') end
+  c.property = function(self, name, getter, setter)
+    assert(_classes[self], 'Properties can only be defined for classes')
+    if not(self.__getters or self.__setters) then
+      self.__getters = {}; self.__setters = {}
+      self.__index = function(self, index) local getter = self.__getters[index]; if getter == false then error("The " .. index .. " property is not readable.") end; if getter then return rawget(self, getter)(self) else return rawget(self, index) end end
+      self.__newindex = function(self, index, value) local setter = self.__setters[index]; if setter == false then error("The " .. index .. " property is not writeable.") end; if setter then rawget(self, setter)(self, value) else rawset(self, index, value) end end
+    end
+    if type(getter) == "function" then rawset(self, "__get_" .. name, getter); getter = "__get_" .. name end
+    if type(setter) == "function" then rawset(self, "__set_" .. name, setter); setter = "__set_" .. name end
+    self.__getters[name] = getter or false; self.__setters[name] = setter or false
+  end
   c.new, c.extends, c.__index, c.__call, c.__tostring = instantiate, extends, c, baseMt.__call, baseMt.__tostring;
   c.is = function(self, kind) local super; while true do super = getmetatable(super or self) ; if super == kind or super == nil then break end ; end;
   return kind and (super == kind) end; return setmetatable(c,baseMt)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2012 - 2014 Roland Yonaba
+Copyright (c) 2014 Llamageddon <asmageddon AT gmail DOT com>
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ luarocks install --server=http://rocks.moonscript.org/manifests/Yonaba 30log
 
 ##Installation
 Copy the file [30log.lua](https://github.com/Yonaba/30log/blob/master/30log.lua) inside your project folder,
-call it using [require](http://pgl.yoyo.org/luai/i/require) function. It will return a single local function, 
+call it using [require](http://pgl.yoyo.org/luai/i/require) function. It will return a single local function,
 keeping safe the global environment.<br/>
 
 ##Quicktour
@@ -66,7 +66,7 @@ Window.x, Window.y = 10, 10
 Window.width, Window.height = 100,100
 ```
 
-You can also make it shorter, packing the default properties and their values within a 
+You can also make it shorter, packing the default properties and their values within a
 table and then pass it as a single argument to the `class` function :
 
 ```lua
@@ -84,14 +84,14 @@ Window = class ()
 Window.__name = 'Window'
 ```
 
-This feature can be quite useful when debugging your code. See the section 
+This feature can be quite useful when debugging your code. See the section
 [printing classes](https://github.com/Yonaba/30log/#printing-classes-and-objects) for more details.
 
 ###Instances
 
 ####Creating instances
 
-You can easily create new __instances__ (objects) from a class using the __default instantiation method__ 
+You can easily create new __instances__ (objects) from a class using the __default instantiation method__
 named `new()`:
 
 ```lua
@@ -108,11 +108,11 @@ print(appFrame.x,appFrame.y) --> 10, 10
 print(appFrame.width,appFrame.height) --> 100, 100
 ```
 
-From the two examples above, you might have noticed that once an object is created from a class, it 
-already shares the properties of his mother class. That's the very basis of `inheritance`. 
+From the two examples above, you might have noticed that once an object is created from a class, it
+already shares the properties of his mother class. That's the very basis of `inheritance`.
 So, by default, the attributes of the newly created object will copy their values from its mother class.<br/>
 <br/>
-Yet, you can init new objects from a class with custom values for properties. To accomplish that, 
+Yet, you can init new objects from a class with custom values for properties. To accomplish that,
 you will have to implement your own __class constructor__. Typically, it is a method (a function) that will be
 called whenever the new() method is used from the class to derive a new object, and then define custom attributes and values for this object.<br/>
 By default, __30log__ uses the reserved key `__init` as a __class constructor__.
@@ -132,7 +132,7 @@ print(appFrame.width,appFrame.height) --> 800, 600
 
 `__init` can also be a __table with named keys__. </br>
 In that case though, the values of each single object's properties will be taken from this table
-upon instantiation, no matter what the values passed-in at instantiation would be. 
+upon instantiation, no matter what the values passed-in at instantiation would be.
 
 ```lua
 Window = class()
@@ -145,7 +145,7 @@ print(appFrame.width,appFrame.height) --> 100, 100
 ````
 
 ####Under the hood
-*30log* classes are metatables of their own instances. This implies that one can inspect the mother/son 
+*30log* classes are metatables of their own instances. This implies that one can inspect the mother/son
 relationship between a class and its instance via Lua's standard function [getmetatable](http://www.lua.org/manual/5.2/manual.html#pdf-getmetatable).
 
 ```lua
@@ -199,7 +199,7 @@ Classes supports metamethods as well as methods. Those metamethods can be inheri
 In the following example, we will use the `+` operator to increase the window size.
 
 ```lua
-Window.__add = function(w, size) 
+Window.__add = function(w, size)
   w.width = w.width + size
   w.height = w.height + size
   return w
@@ -223,7 +223,7 @@ print(frame.width, frame.height) --> 450, 350
 ###Inheritance
 
 A class can __inherit__ from any other class using a reserved method named `extends`.
-Similarly to `class`, this method also takes an optional table with named keys as argument 
+Similarly to `class`, this method also takes an optional table with named keys as argument
 to include __new properties__ that the derived class will implement.
 The new class will inherit his mother class __properties__ as well as its __methods__.
 
@@ -237,7 +237,7 @@ print(appFrame.x,appFrame.y) --> 10, 10
 ```
 
 A derived class can __redefine any method__ implemented in its base class (or mother class).
-Therefore, the derived class *still* has access to his mother class methods and properties via a 
+Therefore, the derived class *still* has access to his mother class methods and properties via a
 reserved key named `super`.<br/>
 
 ```lua
@@ -320,7 +320,7 @@ print(anObject:is(aClass)) --> true
 ````
 
 ##Chained initialisation
-In a single inheritance tree,  the `__init` constructor can be chained from one class to 
+In a single inheritance tree,  the `__init` constructor can be chained from one class to
 another.<br/>
 
 This is called *initception*.<br/>
@@ -394,7 +394,7 @@ end
 
 ##Mixins
 
-__30log__ provides a basic support for [mixins](http://en.wikipedia.org/wiki/Mixin). This is a powerful concept that can 
+__30log__ provides a basic support for [mixins](http://en.wikipedia.org/wiki/Mixin). This is a powerful concept that can
 be used to implement a functionality into different classes, even if they do not have any special relationship.<br/>
 __30log__ assumes a `mixin` to be a table containing a **set of methods** (function).<br/>
 To include a mixin in a class, use the reserved key named `include`.
@@ -426,13 +426,95 @@ aWindow:resize(225,75)
 print(aWindow.width, aWindow.height) --> 255, 75
 ````
 
-Note that, when including a mixin into a class, **only methods** (functions, actually) will be imported into the 
+Note that, when including a mixin into a class, **only methods** (functions, actually) will be imported into the
 class. Also, objects cannot include mixins.
 
 ```lua
 aWindow = Window()
 aWindow:include(Geometry) -- produces an error
 ````
+
+##Properties
+
+It's possible to define properties as pair of getter/setter method as a form of synctatic sugar for using them.<br/>
+To define a property, use the reserved key name `property`.
+
+```lua
+-- Defining properties
+Window = class { _width = 200, _height = 200, max_width = 640, max_height = 480}
+function Window:setWidth(width)
+    self._width = math.min(width, self.max_width)
+end
+function Window:setHeight(height)
+    self._height = math.min(height, self.max_height)
+end
+function Window:getWidth() return self._width end
+function Window:getHeight() return self._height end
+Window:property("width", "getWidth", "setWidth")
+Window:property("height", "getHeight", "setHeight")
+
+someWindow = Window()
+
+print(someWindow.width, someWindow.height) --> 200, 200
+someWindow.width = 512
+print(someWindow.width, someWindow.height) --> 512, 200
+someWindow.height = 1280
+print(someWindow.width, someWindow.height) --> 512, 480
+```
+
+It's also possible to redefine getters/setters in subclasses
+
+```lua
+-- Redefining getters/setters in subclasses
+DialogWindow = Window:extends { min_width = 80, min_height = 60}
+function DialogWindow:setWidth(width)
+    self._width = math.max(math.min(width, self.max_width), self.min_width)
+end
+function DialogWindow:setHeight(height)
+    self._height = math.max(math.min(height, self.max_height), self.min_height)
+end
+
+otherWindow = DialogWindow()
+
+print(otherWindow.width, otherWindow.height) --> 200, 200
+otherWindow.width = 12
+print(otherWindow.width, otherWindow.height) --> 80, 200
+otherWindow.width = 1280
+print(otherWindow.width, otherWindow.height) --> 640, 200
+
+-- Defining anonymous getters/setters and read/write-only properties
+```
+
+You can also declare getters/setters using anonymous methods
+
+```lua
+-- Defining anonymous getters/setters and read/write-only properties
+
+Canvas = class()
+
+function Canvas:__init(parent_window)
+    self.parent = parent_window
+    self._random_seed = 0
+end
+
+Canvas:property("width", function() return self.parent.width end, nil)
+Canvas:property("height", function() return self.parent.height end, nil)
+Canvas:property("random_seed", nil, function(value) self._random_seed = value or 0 end)
+
+drawingWindow = Window()
+theCanvas = Canvas(drawingWindow)
+
+print(theCanvas.width, theCanvas.height) --> 200, 200
+drawingWindow.height = 400
+print(theCanvas.width, theCanvas.height) --> 200, 400
+
+theCanvas.width = 250 --> Error: example_code.lua:xxx: The width property is not writeable.
+theCanvas.height = 50 --> Error: example_code.lua:xxx: The height property is not writeable.
+
+theCanvas.random_seed = nil --> Sets _random_seed to 0
+theCanvas.random_seed = 42 --> Sets _random_seed to 42
+print(theCanvas.random_seed) --> Error: example_code.lua:xxx: The random_seed property is not readable.
+```
 
 ##Printing classes and objects
 Any attempt to [print](http://pgl.yoyo.org/luai/i/print) or [tostring](http://pgl.yoyo.org/luai/i/tostring) a __class__ or an __instance__
@@ -464,14 +546,14 @@ print(kitten) --> "object(of Cat):<table:00411880>"
 ````
 
 ##Class Commons
-[Class-Commons](https://github.com/bartbes/Class-Commons) is an interface that provides a common 
-API for a wide range of object orientation libraries in Lua. There is a small plugin, originally written by [TsT](https://github.com/tst2005) 
+[Class-Commons](https://github.com/bartbes/Class-Commons) is an interface that provides a common
+API for a wide range of object orientation libraries in Lua. There is a small plugin, originally written by [TsT](https://github.com/tst2005)
 which provides compatibility between *30log* and *Class-commons*. <br/>
 See here: [30logclasscommons](http://github.com/Yonaba/30logclasscommons).
 
 ##Specification
 
-You can run the included specs with [Telescope](https://github.com/norman/telescope) using the following 
+You can run the included specs with [Telescope](https://github.com/norman/telescope) using the following
 command from the root foolder:
 
 ```
@@ -483,12 +565,12 @@ lua tsc -f specs/*
 ###30logclean
 __30log__ was initially designed for minimalistic purposes. But then commit after commit, I came up with a source code
 that was obviously surpassing 30 lines. As I wanted to stick to the "30-lines" rule, I had to use an ugly syntax which not much elegant, yet 100 % functional.<br/>
-For those who might be interested though, the file [30logclean.lua](https://github.com/Yonaba/30log/blob/master/30logclean.lua) contains the full source code, 
+For those who might be interested though, the file [30logclean.lua](https://github.com/Yonaba/30log/blob/master/30logclean.lua) contains the full source code,
 properly formatted and well indented for your perusal.
 
 ###30logglobal
 
-The file [30logglobal.lua](https://github.com/Yonaba/30log/blob/master/30logglobal.lua) features the exact same source as the original [30log.lua](https://github.com/Yonaba/30log/blob/master/30log.lua), 
+The file [30logglobal.lua](https://github.com/Yonaba/30log/blob/master/30logglobal.lua) features the exact same source as the original [30log.lua](https://github.com/Yonaba/30log/blob/master/30log.lua),
 excepts that it sets a global function named `class`. This is convenient for Lua-based frameworks such as [Codea](http://twolivesleft.com/Codea/).
 
 ##Benchmark

--- a/performance/tests.lua
+++ b/performance/tests.lua
@@ -72,6 +72,16 @@ addTest('Accessing instance attribute through setter', function()
   instance:setAttribute(1)
 end)
 
+klass:property("property", "getAttribute", "setAttribute")
+
+addTest('Accessing instance property getter', function()
+  return instance.property
+end)
+
+addTest('Accessing instance property setter', function()
+  instance.property = 1
+end)
+
 local derivedKlass
 addTest('Extending from a class', function()
   derivedKlass = klass:extends()
@@ -90,6 +100,14 @@ end)
 
 addTest('Calling inherited setter method (1-lvl depth)', function()
   derivedInstance:setAttribute(1)
+end)
+
+addTest('Accessing derived instance property getter (1-lvl depth)', function()
+  return derivedInstance.property
+end)
+
+addTest('Accessing derived instance property setter (1-lvl depth)', function()
+  derivedInstance.property = 1
 end)
 
 -- Running all tests

--- a/specs/properties.lua
+++ b/specs/properties.lua
@@ -1,0 +1,127 @@
+require 'luacov'
+local Class = require '30log'
+
+context('Properties', function()
+
+  test('can be defined and accessed', function()
+    local theClass = Class()
+    theClass:property("prop", function(self) return 1 end, nil)
+
+    local instance = theClass()
+
+    assert_true(instance.prop ~= nil)
+    assert_equal(instance.prop, 1)
+  end)
+
+  test('can be set and read using anonymous methods', function()
+    local theClass = Class()
+    function theClass:__init() self.value = 0 end
+    theClass:property("prop",
+        function(self) return self.value end,
+        function(self, value) self.value = value end
+    )
+
+    local instance = theClass()
+
+    assert_equal(instance.prop, instance.value)
+    assert_equal(instance.prop, 0)
+    instance.prop = 2
+    instance.prop = 1
+    assert_equal(instance.prop, instance.value)
+    assert_equal(instance.prop, 1)
+    instance.prop = 2e8
+    assert_equal(instance.prop, instance.value)
+    assert_equal(instance.prop, 2e8)
+  end)
+
+  test('can be inherited', function()
+    local theClass = Class()
+    function theClass:__init() self.value = 0 end
+    function theClass:getProperty() return self.value end
+    function theClass:setProperty(value) self.value = value end
+    theClass:property("prop", "getProperty", "setProperty")
+
+    local inheritedClass = theClass:extends()
+    local inheritedInstance = inheritedClass()
+
+    assert_equal(inheritedInstance.prop, inheritedInstance.value)
+    assert_equal(inheritedInstance.prop, 0)
+    inheritedInstance.prop = 1
+    assert_equal(inheritedInstance.prop, inheritedInstance.value)
+    assert_equal(inheritedInstance.prop, 1)
+    inheritedInstance.prop = 2e8
+    assert_equal(inheritedInstance.prop, inheritedInstance.value)
+    assert_equal(inheritedInstance.prop, 2e8)
+  end)
+
+  test("it's possible to replace class getter/setter methods in a subclass", function()
+    local theClass = Class()
+    function theClass:__init() self.value = 0 end
+    function theClass:getProperty() return self.value end
+    function theClass:setProperty(value) self.value = value end
+    theClass:property("prop", "getProperty", "setProperty")
+
+    local inheritedClass = theClass:extends()
+    function inheritedClass:getProperty() return self.value * 2 end
+    function inheritedClass:setProperty(value) self.value = value * 2 end
+
+    local inheritedInstance = inheritedClass()
+
+    assert_equal(inheritedInstance.prop, 0)
+    inheritedInstance.prop = 1
+    assert_equal(inheritedInstance.prop, inheritedInstance.value * 2)
+    assert_equal(inheritedInstance.prop, 4)
+    inheritedInstance.prop = 2e8
+    assert_equal(inheritedInstance.prop, inheritedInstance.value * 2)
+    assert_equal(inheritedInstance.prop, 2e8 * 4)
+  end)
+
+  test("can be declared as read-only", function()
+    local theClass = Class()
+
+    function theClass:__init() self.value = 42 end
+    function theClass:getProperty() return self.value end
+
+    theClass:property("prop", "getProperty", nil)
+
+    local instance = theClass()
+
+    assert_equal(instance.prop, instance.value)
+    assert_equal(instance.prop, 42)
+    assert_error(function() instance.prop = 42 end)
+    assert_error(function() instance.prop = 0 end)
+    assert_error(function() instance.prop = 3e44 end)
+  end)
+
+  test("can be declared as write-only", function()
+    local theClass = Class()
+    function theClass:__init() self.value = 42 end
+    function theClass:setProperty(value) self.value = value end
+    theClass:property("prop", nil, "setProperty")
+
+    local instance = theClass()
+
+    assert_equal(instance.value, 42)
+    assert_error(function() return instance.prop end)
+    instance.prop = 13
+    assert_equal(instance.value, 13)
+    assert_error(function() return instance.prop end)
+    instance.prop = 7e3 + 123
+    instance.prop = 5e7 + 321337
+    instance.prop = 12
+    assert_equal(instance.value, 12)
+    assert_error(function() return instance.prop end)
+  end)
+
+  test("can be declared as unwriteable and unreadable", function()
+    local theClass = Class()
+    theClass:property("prop", nil, nil)
+
+    local instance = theClass()
+
+    assert_error(function() return instance.prop end)
+    assert_error(function() instance.prop = 12 end)
+  end)
+
+end)
+


### PR DESCRIPTION
Includes unit tests, benchmarks(surprisingly - the property system is faster than invoking getter/setter methods.... somehow, on both Lua 5.2 and LuaJIT), and source code minified down to 30 lines(although some of them are getting fairly long).

What it does not include is updated version history.

Also, it makes using `__newindex` and `__index` together with properties impossible, potentially breaking backwards compatibility if properties are also used. I can add support for that, but the code length is going to grow.

I would love some input on this. Do you think I should perhaps make a fork instead?