### PR TITLE
Fix README headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ which provides compatibility between *30log* and *Class-commons*. <br/>
 See the module [30log-commons.lua](https://github.com/Yonaba/30log/blob/master/30log-commons.lua).
 
 
-##Specs
+## Specs
 
 You can run the included specs with [Telescope](https://github.com/norman/telescope) using the following command from Lua from the root foolder:
 
@@ -55,18 +55,18 @@ lua tsc -f specs/*
 
 ## About the source
 
-####30log-clean.lua
+#### 30log-clean.lua
 
 *30log* was initially designed for minimalistic purposes. But then commit after commit, I came up with a source code that was obviously surpassing 30 lines. As I wanted to stick to the "30-lines" rule that defines the name of this library, I had to use an ugly syntax which not much elegant, yet 100 % functional.<br/>
 For those who might be interested though, the file [30log-clean.lua](http://github.com/Yonaba/30log/blob/master/30log-clean.lua) contains the full source code, properly formatted and well indented for your perusal.
 
-####30log-global.lua
+#### 30log-global.lua
 
 The file [30log-global.lua](http://github.com/Yonaba/30log/blob/master/30log-global.lua) features the exact same source as the original [30log.lua](http://github.com/Yonaba/30log/blob/master/30log.lua), 
 excepts that it sets a global named `class`. This is convenient for Lua-based frameworks such as [Codea](http://twolivesleft.com/Codea/).
 
 
-####30log-singleton.lua
+#### 30log-singleton.lua
 
 The file [30log-singleton.lua](http://github.com/Yonaba/30log/blob/master/30log-global.lua) is a [singleton pattern](http://en.wikipedia.org/wiki/Singleton_pattern) implementation for use with *30log*.
 
@@ -76,6 +76,6 @@ The file [30log-singleton.lua](http://github.com/Yonaba/30log/blob/master/30log-
 * [Srdjan Marković](https://github.com/Yonaba/30log/blob/master/LICENSE#L22-L31) for the awesome graphic logo design.
 
 
-##License
+## License
 
 This work is [MIT-Licensed](https://raw.githubusercontent.com/Yonaba/30log/master/LICENSE).


### PR DESCRIPTION
For some reason github's markdown syntax changed a while ago.